### PR TITLE
Add Consul Token option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can install Consul Imex in several ways:
 
 * Executable phar file (requires PHP >=5.5.9)
 * Docker image (requires [Docker](https://www.docker.com/) engine)
-* Composer dependancy (requires [Git](https://git-scm.com/), [Composer](https://getcomposer.org/) and PHP >=5.5.9)
+* Composer dependency (requires [Git](https://git-scm.com/), [Composer](https://getcomposer.org/) and PHP >=5.5.9)
 * Single PHP project (requires [Git](https://git-scm.com/), [Composer](https://getcomposer.org/) and PHP >=5.5.9)
 
 ### Install as an executable phar file
@@ -81,7 +81,7 @@ See [Notices for Docker Usage](#notices-for-docker-usage) for detailed informati
 
 * **--url (-u):** Consul server url.
 * **--prefix (-p):** Path prefix.
-
+* **--token (-c):** Consul token.
 
 ### Import
 
@@ -97,6 +97,7 @@ See [Notices for Docker Usage](#notices-for-docker-usage) for detailed informati
 
 * **--url (-u):** Consul server url.
 * **--prefix (-p):** Path prefix.
+* **--token (-c):** Consul token.
 
 ### Copy
 
@@ -113,6 +114,8 @@ See [Notices for Docker Usage](#notices-for-docker-usage) for detailed informati
 
 * **--source-server (-s):** Source server URL.
 * **--target-server (-t):** Target server URL. If omitted, source server is used as target server.
+* **--source-server-token (-c):** Source server Consul token.
+* **--target-server-token:** Target server Consul token. If omitted, source server token is used as target server token.
 
 ## Examples
 
@@ -120,10 +123,20 @@ See [Notices for Docker Usage](#notices-for-docker-usage) for detailed informati
 
     $ consul-imex export -u http://localhost:8500 -p /old/prefix my-data.json
     93 keys are fetched.
+   
+Export using token key:
+
+    $ consul-imex export -c 4874874a-2a3s-7892-123e-597a4e1v87e1 -u http://localhost:8500 -p /old/prefix my-data.json
+    93 keys are fetched.
 
 ### Import
 
     $ consul-imex import -u http://localhost:8500 -p /new/prefix my-data.json
+    93 keys are stored. (25 new directories are created.)
+   
+Import using token key:
+
+    $ consul-imex import -c 4874874a-2a3s-7892-123e-597a4e1v87e1 -u http://localhost:8500 -p /new/prefix my-data.json
     93 keys are stored. (25 new directories are created.)
 
 ### Copy
@@ -135,10 +148,24 @@ Copy keys from `/old/prefix` to `/new/prefix`:
     93 keys are stored. (25 new directories are created.)
     Operation completed.
 
+Copy keys from `/old/prefix` to `/new/prefix` using token:
+
+    $ consul-imex copy -s http://localhost:8500 -c 4874874a-2a3s-7892-123e-597a4e1v87e1 /old/prefix /new/prefix
+    93 keys are fetched.
+    93 keys are stored. (25 new directories are created.)
+    Operation completed.
+
 
 Copy keys under `/my/prefix` to another server:
 
     $ consul-imex copy -s http://localhost:8500 -t http://anotherhost:8500 /my/prefix /my/prefix
+    93 keys are fetched.
+    93 keys are stored. (25 new directories are created.)
+    Operation completed.
+
+Copy keys under `/my/prefix` to another server using token:
+
+    $ consul-imex copy -s http://localhost:8500 -c 4874874a-2a3s-7892-123e-597a4e1v87e1 -t http://anotherhost:8500 --target-server-token 6242c15a-9w4x-2318-61a2-8as8c47317 /my/prefix /my/prefix
     93 keys are fetched.
     93 keys are stored. (25 new directories are created.)
     Operation completed.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/console": "^3.0",
-        "guzzlehttp/guzzle": "^6.1",
+        "guzzlehttp/guzzle": "^6.3",
         "ext-json": "~1.3"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "beaa0ee65db519599f3d85c297bda8cc",
+    "hash": "9f4370141947be7d687b77d05c50a863",
+    "content-hash": "bb6566f857a43c9b0e5d53f2fb938d63",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.3",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
                 "shasum": ""
             },
             "require": {
@@ -27,13 +28,16 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
                 "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.2-dev"
+                    "dev-master": "6.3-dev"
                 }
             },
             "autoload": {
@@ -66,7 +70,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-02-28T22:50:30+00:00"
+            "time": "2018-04-22 15:46:56"
         },
         {
             "name": "guzzlehttp/promises",
@@ -117,7 +121,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20T10:07:11+00:00"
+            "time": "2016-12-20 10:07:11"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -182,7 +186,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2017-03-20 17:10:46"
         },
         {
             "name": "psr/http-message",
@@ -232,7 +236,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "psr/log",
@@ -279,7 +283,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "symfony/console",
@@ -342,7 +346,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-06T19:30:27+00:00"
+            "time": "2017-03-06 19:30:27"
         },
         {
             "name": "symfony/debug",
@@ -399,7 +403,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-18T17:28:00+00:00"
+            "time": "2017-02-18 17:28:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -458,7 +462,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         }
     ],
     "packages-dev": [
@@ -504,7 +508,7 @@
                 }
             ],
             "description": "Gamegos PHP Code Sniffer",
-            "time": "2017-03-22T13:27:19+00:00"
+            "time": "2017-03-22 13:27:19"
         }
     ],
     "aliases": [],

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -43,6 +43,12 @@ abstract class AbstractCommand extends Command
     protected $prefix = '';
 
     /**
+     * Consul token for current operation.
+     * @var string
+     */
+    protected $token = '';
+
+    /**
      * HTTP Client
      * @var \GuzzleHttp\Client
      */
@@ -62,6 +68,7 @@ abstract class AbstractCommand extends Command
         $this->addArgument('file', InputArgument::REQUIRED);
         $this->addOption('url', 'u', InputOption::VALUE_REQUIRED, 'Consul server url.', self::DEFAULT_URL);
         $this->addOption('prefix', 'p', InputOption::VALUE_REQUIRED, 'Path prefix.', '');
+        $this->addOption('token', 'c', InputOption::VALUE_OPTIONAL, 'Consul token.');
     }
 
     /**
@@ -69,6 +76,10 @@ abstract class AbstractCommand extends Command
      */
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption('token') !== null) {
+            $this->token = $input->getOption('token');
+        }
+
         $this->healthCheck($input);
 
         $this->prefix = trim($input->getOption('prefix'), '/');
@@ -87,7 +98,11 @@ abstract class AbstractCommand extends Command
     protected function getHttpClient()
     {
         if (null === $this->httpClient) {
-            $this->httpClient = new Client();
+            $options = [];
+            if ($this->token) {
+                $options['headers']['X-Consul-Token'] = $this->token;
+            }
+            $this->httpClient = new Client($options);
         }
         return $this->httpClient;
     }

--- a/src/Command/CopyCommand.php
+++ b/src/Command/CopyCommand.php
@@ -33,6 +33,8 @@ class CopyCommand extends Command
         $this->addArgument('target', InputArgument::REQUIRED, 'Target prefix.');
         $this->addOption('source-server', 's', InputOption::VALUE_REQUIRED, 'Source server URL.');
         $this->addOption('target-server', 't', InputOption::VALUE_REQUIRED, 'Target server URL. If omitted, source server is used as target server.');
+        $this->addOption('source-server-token', 'c', InputOption::VALUE_OPTIONAL, 'Source server Consul token.');
+        $this->addOption('target-server-token', null, InputOption::VALUE_OPTIONAL, 'Target server Consul token. If omitted, source server token is used as target server token.');
     }
 
     /**
@@ -53,6 +55,9 @@ class CopyCommand extends Command
         if ($input->getOption('source-server') !== null) {
             $exportParams['--url'] = $input->getOption('source-server');
         }
+        if ($input->getOption('source-server-token') !== null) {
+            $exportParams['--token'] = $input->getOption('source-server-token');
+        }
 
         // Run the 'export' command.
         $exportReturn = $exportCommand->run(new ArrayInput($exportParams), $output);
@@ -71,6 +76,11 @@ class CopyCommand extends Command
             $importParams['--url'] = $input->getOption('target-server');
         } elseif ($input->getOption('source-server') !== null) {
             $importParams['--url'] = $input->getOption('source-server');
+        }
+        if ($input->getOption('target-server-token') !== null) {
+            $importParams['--token'] = $input->getOption('target-server-token');
+        } elseif ($input->getOption('source-server-token') !== null) {
+            $importParams['--token'] = $input->getOption('source-server-token');
         }
 
         // Run the 'import' command.

--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -58,7 +58,7 @@ class ExportCommand extends AbstractCommand
 
     /**
      * Get the keys under current prefix from Consul.
-     * @throws \Gamegos\ConsulImex\ExportException
+     * @throws \Gamegos\ConsulImex\Command\ExportException
      * @return array
      */
     protected function getKeys()
@@ -85,7 +85,7 @@ class ExportCommand extends AbstractCommand
     }
 
     /**
-     * Fetch a value from Consul into a buffer with reccursive index.
+     * Fetch a value from Consul into a buffer with recursive index.
      * @param  array $buffer Buffer that the value will be added in.
      * @param  string $path Path of a key that is relative to current prefix.
      * @return bool


### PR DESCRIPTION
guzzlehttp problem fixed. [bug report](https://github.com/guzzle/guzzle/issues/1973#issuecomment-350464169)
consul token support added. [ref](https://www.consul.io/docs/guides/acl.html)
readme updated for consul token option and added useful docker parameters